### PR TITLE
Implement s3ForcePathStyle with s3 aws

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ S3_BUCKET=your_bucket
 # If you are using Amazon S3 then only set region.
 # However if you are using some other provider then only set endpoint.
 # Region and endpoint both should not be set together.
+# If you want to to force path style URLs for S3 objects Set AWS_USE_PATH_STYLE_ENDPOINT as a true
+# It will replace  https://{service}.{region}.amazonaws.com to the endpoint 
 
 S3_REGION=your_region
 # S3_ENDPOINT=your_endpoint
@@ -70,6 +72,7 @@ if (mix.inProduction()) {
                 bucket: process.env.S3_BUCKET,
                 region: process.env.S3_REGION,
                 // endpoint: process.env.S3_ENDPOINT,
+                // s3ForcePathStyle: process.env.AWS_USE_PATH_STYLE_ENDPOINT, //#(endpoint required)
                 prefix: 'assets',
                 acl: 'public-read',
                 cache: 'max-age=602430',

--- a/webpack.s3.pusher.js
+++ b/webpack.s3.pusher.js
@@ -44,6 +44,10 @@ function S3PusherPlugin(options) {
       config.endpoint = options.endpoint
     }
 
+    if (options.s3ForcePathStyle) {
+        config.s3ForcePathStyle = options.s3ForcePathStyle
+    }
+    
     AWS.config.update(config)
   }
 


### PR DESCRIPTION
I would like to add a simple edit to allow override the whole link by configuring it 

```
s3ForcePathStyle: true,
```

it will change all link https://{service}.{region}.amazonaws.com to the endpoint & help to working with another bucket like minio


https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#s3ForcePathStyle-property
https://github.com/laravel/laravel/blob/c5d38d469a447d6831c3cf56d193be7941d6586f/config/filesystems.php#L53